### PR TITLE
mainly correcting pointer bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+

--- a/COREM/Makefile
+++ b/COREM/Makefile
@@ -5,9 +5,9 @@ MAKEFILE      = Makefile
 CC            = gcc
 CXX           = g++
 CFLAGS        = -m64 -pipe -O2 -Wall -W -D_REENTRANT -fPIE $(DEFINES)
-CXXFLAGS      = -m64 -pipe -fopenmp -std=c++0x -O2 -Wall -W -D_REENTRANT -fPIE $(DEFINES)
+CXXFLAGS      = -m64 -pipe -fopenmp -std=c++0x -O2 -Wall -Wno-unused-parameter -W -D_REENTRANT -fPIE $(DEFINES)
 LINK          = g++
-LFLAGS        = -m64 -fopenmp -Wl,-O1 -Wl
+LFLAGS        = -m64 -fopenmp -Wl,-O1
 LIBS          = $(SUBLIBS) -lX11 -lpthread 
 AR            = ar cqs
 TAR           = tar -cf

--- a/COREM/src/DisplayManager.cpp
+++ b/COREM/src/DisplayManager.cpp
@@ -332,9 +332,9 @@ void DisplayManager::updateDisplay(CImg <double> *input, Retina &retina, int ste
                 strs1 << (int)min;
 
             string str1 = strs1.str();
-            const char * min_value_text = (str1.substr(0,4)).c_str();
+            string min_value_text = str1.substr(0,4);
 
-            bars[k]->draw_text(0,bars[k]->height()-20,min_value_text,color,0,1,20);
+            bars[k]->draw_text(0,bars[k]->height()-20,min_value_text.c_str(),color,0,1,20);
 
             if(abs(max)<100)
                 strs2 << max;
@@ -343,9 +343,9 @@ void DisplayManager::updateDisplay(CImg <double> *input, Retina &retina, int ste
 
 
             string str2 = strs2.str();
-            const char * max_value_text = (str2.substr(0,4)).c_str();
+            string max_value_text = str2.substr(0,4);
 
-            bars[k]->draw_text(0,10,max_value_text,color,0,1,20);
+            bars[k]->draw_text(0,10,max_value_text.c_str(),color,0,1,20);
 
             // show image
             intermediateImages[k]->crop(margin[k+1],margin[k+1],0,0,sizeY-margin[k+1]-1,sizeX-margin[k+1]-1,0,0,false);

--- a/COREM/src/FileReader.cpp
+++ b/COREM/src/FileReader.cpp
@@ -138,7 +138,7 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                             action = 15;
                         }
                         else{
-                            abort(line);
+                            abort(line,"Unknown action command");
                             break;
                         }
                     }
@@ -146,7 +146,7 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                 }
                 else if (*token[0] != '#')
                 {
-                    abort(line);
+                    abort(line,"neither 'retina' nor '#' token found at line beginning");
                     break;
                 }
 
@@ -188,7 +188,7 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                     }
 
                     else{
-                        abort(line);
+                        abort(line,"Unknown module type");
                         break;
                     }
 
@@ -214,11 +214,11 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
 
                                     i+=2;
                                 }else{
-                                    abort(line);
+                                    abort(line,"Incorrect parameter format");
                                     break;
                                 }
                                 if (!token[i]){
-                                    abort(line);
+                                    abort(line,"Incorrect format of parameters");
                                     break;
                                 }
                             }
@@ -231,18 +231,18 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                                 if(continueReading){
                                     retina.addModule(newModule,token[3]);
                                 }else{
-                                    abort(line);
+                                    abort(line,"Error setting specified parameters");
                                     break;
                                 }
                             }
 
 
                         }else{
-                            abort(line);
+                            abort(line,"Incorrect parameter start format");
                             break;
                         }
                     }else{
-                        abort(line);
+                        abort(line,"No parameter start found");
                         break;
                     }
 
@@ -279,14 +279,14 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                                     operations.push_back(1);
                                 }else
                                 {
-                                    abort(line);
+                                    abort(line,"Neither '+' or '-' token found");
                                     break;
                                 }
                                 change=true;
                             }
                             i+=1;
                             if (!token[i]){
-                                abort(line);
+                                abort(line,"Expected token not found");
                                 break;
                             }
                         }
@@ -298,12 +298,12 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                             if(verbose)cout << "Modules connected to "<< token[i+1] << endl;
 
                             if (!continueReading){
-                                abort(line);
+                                abort(line,"Error connecting expecified modules");
                                 break;
                             }
 
                         }else{
-                            abort(line);
+                            abort(line,"Expected two module IDs and correct format");
                             break;
                         }
 
@@ -314,12 +314,12 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                         continueReading=retina.connect(modulesID,token[3],operations,token[4]);
                         if(verbose)cout << "Modules connected to "<< token[3] << endl;
                         if (!continueReading){
-                            abort(line);
+                            abort(line,"Incorrect module IDs for connect action command");
                             break;
                         }
                     }
                 }else{
-                    abort(line);
+                    abort(line,"Not enough parameters");
                     break;
                 }
 
@@ -332,11 +332,11 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                     if (atof(token[2])>0)
                         retina.set_step(atof(token[2]));
                     else{
-                        abort(line);
+                        abort(line,"Expected positive value (>0)");
                         break;
                     }
                 }else{
-                    abort(line);
+                    abort(line,"Expected temporal step value");
                     break;
                 }
 
@@ -353,17 +353,17 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                             if(verbose)cout << "Pixels per degree = " << atof(token[3]) << endl;
                         }
                         else{
-                            abort(line);
+                            abort(line,"Expected positive parameter (>0)");
                             break;
                         }
                     }else{
-                        abort(line);
+                        abort(line,"Expected '{' and '}' around parameter");
                         break;
                     }
 
 
                 }else{
-                    abort(line);
+                    abort(line,"Expected pixel per degree parameter");
                     break;
                 }
 
@@ -377,11 +377,11 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                     if (atof(token[2])>0)
                         retina.setRepetitions(atof(token[2]));
                     else{
-                        abort(line);
+                        abort(line,"Expected a positive number of repetitions (>0)");
                         break;
                     }
                 }else{
-                    abort(line);
+                    abort(line,"Expected value of number of repetitions");
                     break;
                 }
 
@@ -395,11 +395,11 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                     if (atof(token[2])>=0)
                         displayMg.setDelay(atof(token[2]));
                     else{
-                        abort(line);
+                        abort(line,"Expected positive or zero value (>=0)");
                         break;
                     }
                 }else{
-                    abort(line);
+                    abort(line,"Expected value of display delay");
                     break;
                 }
 
@@ -414,11 +414,11 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                     if (atof(token[2])>0)
                         displayMg.setImagesPerRow(atof(token[2]));
                     else{
-                        abort(line);
+                        abort(line,"Expected a positive value (>0)");
                         break;
                     }
                 }else{
-                    abort(line);
+                    abort(line,"Expected number of windows");
                     break;
                 }
 
@@ -442,7 +442,7 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                                 retina.setRepetitions(1.0);
                                 if(verbose)cout << "Grating generated." << endl;
                             }else{
-                                abort(line);
+                                abort(line,"Expected parameter list of grating: 'type','step','length1','length2','length3','sizeX','sizeY','freq','period','Lum','Contr','phi_s','phi_t','orientation','red_weight','green_weight','blue_weight','red_phase','green_phase','blue_phase'");
                                 break;
                             }
                         }else if(strcmp(token[2], "fixationalMovGrating") == 0 ){
@@ -452,7 +452,7 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                                 retina.setRepetitions(1.0);
                                 if(verbose)cout << "Grating of fixational movements generated." << endl;
                             }else{
-                                abort(line);
+                                abort(line,"Expected parameter list of fixationalMovGrating: 'sizeX','sizeY','circle_radius','jitter_period','spatial_period','step_size','Lum','Contr','orientation','red_weight','green_weight','blue_weight','type1','type2','switch'");
                                 break;
                             }
 
@@ -462,7 +462,7 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                                 retina.setRepetitions(1.0);
                                 if(verbose)cout << "White noise generated." << endl;
                             }else{
-                                abort(line);
+                                abort(line,"Expected parameter list of whiteNoise: 'mean','contrast1','contrast2','period','switch','sizeX','sizeY'");
                                 break;
                             }
                         }
@@ -472,23 +472,23 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                                 retina.setRepetitions(1.0);
                                 if(verbose)cout << "Impulse generated." << endl;
                             }else{
-                                abort(line);
+                                abort(line,"Expected parameter list of impulse: 'start','stop','amplitude','offset','sizeX','sizeY'");
                                 break;
                             }
                         }
                         else{
-                            abort(line);
+                            abort(line,"Unknown input type");
                             break;
                         }
 
 
                     }
                     else{
-                        abort(line);
+                        abort(line,"Parameter start token ('{') not found");
                         break;
                     }
                 }else{
-                    abort(line);
+                    abort(line,"Tokens for input action command not found");
                     break;
                 }
 
@@ -509,16 +509,16 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
             case 11:
 
                 if (token[2] && token[3] && token[4] && token[5]){
-
+                    bool module_id_found;
                     // Search for the module ID
+                    module_id_found=false;
                     continueReading=false;
                     for(int l=1;l<retina.getNumberModules();l++){
                         module *m = retina.getModule(l);
-                        const char * ID = (m->getModuleID()).c_str();
-
-                        if(strcmp(token[2],ID)==0){
+                        string ID = m->getModuleID();
+                        if(ID.compare(token[2])==0){
                             continueReading=true;
-
+                            module_id_found=true;
                             if(strcmp(token[3],"True")==0){
                                 displayMg.setIsShown(true,l);
                                 if(verbose)cout << "Module "<<  token[2] <<" is displayed." << endl;
@@ -530,7 +530,7 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                                 if(verbose)cout << "Module "<<  token[2] <<" is not displayed." << endl;
                             }
                             else{
-                                abort(line);
+                                abort(line,"Expected a 'True' or 'False' value after module ID");
                                 break;
                             }
 
@@ -552,7 +552,7 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                                 if(verbose)cout << "Module "<<  token[2] <<" is not displayed." << endl;
                             }
                             else{
-                                abort(line);
+                                abort(line,"Expected 'True' or 'False' value for Input");
                                 break;
                             }
 
@@ -561,9 +561,12 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                             }
 
                     }
+                    else
+                        if(!module_id_found)
+                            abort(line,"Specified module ID not found");
 
                 }else{
-                    abort(line);
+                    abort(line,"Parameters for Show window not found");
                     break;
                 }
 
@@ -581,17 +584,17 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                             if(verbose)cout << "Display zoom = " << atof(token[3]) << endl;
                         }
                         else{
-                            abort(line);
+                            abort(line,"Expected a positive value (>0)");
                             break;
                         }
                     }else{
-                        abort(line);
+                        abort(line,"Expected '{' and '}' around parameter value");
                         break;
                     }
 
 
                 }else{
-                    abort(line);
+                    abort(line,"Expected parameters for Windows Zoom not found");
                     break;
                 }
 
@@ -605,7 +608,7 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                     // read multimeter type
                     if (strcmp(token[2], "spatial") != 0 && strcmp(token[2], "temporal") != 0 && strcmp(token[2], "Linear-Nonlinear") != 0)
                     {
-                        abort(line);
+                        abort(line,"Expected any of the parameters for multimeter: 'spatial','temporal','Linear-Nonlinear'");
                         break;
                     }
 
@@ -637,45 +640,47 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                                         else
                                             continueReading=false;
                                     }else{
-                                        abort(line);
+                                        abort(line,"Expected spatial multimeter parameter list: 'timeStep','rowcol','value','Show'");
                                         break;
                                     }
                                 }else if(strcmp(token[2], "temporal") == 0 && token[6] && token[7] && token[8] && token[9] && token[10] && token[11] && token[12]){
                                     if(strcmp(token[6], "x") == 0 && strcmp(token[8], "y") == 0 && strcmp(token[11], "Show") == 0){
                                         displayMg.addMultimeterTempSpat(token[3],token[4],atof(token[7]),atof(token[9]),true,token[12]);
                                     }else{
-                                        abort(line);
+                                        abort(line,"Expected temporal multimeter parameter list: 'x','y','Show'");
                                         break;
                                     }
                                 }else if(strcmp(token[2], "Linear-Nonlinear") == 0 && token[6] && token[7] && token[8] && token[9] && token[10] && token[11] && token[12] && token[13] && token[14] && token[15] && token[16] && token[17] && token[18] && token[19] && token[20]){
                                     if(strcmp(token[6], "x") == 0 && strcmp(token[8], "y") == 0 && strcmp(token[10], "segment") == 0 && strcmp(token[12], "interval") == 0 && strcmp(token[14], "start") == 0 && strcmp(token[16], "stop") == 0 && strcmp(token[18], "Show") == 0){
                                         displayMg.addMultimeterLN(token[3],token[4],atof(token[7]),atof(token[9]),atof(token[11]),atof(token[13]),atof(token[15]),atof(token[17]),token[19]);
                                     }else{
-                                        abort(line);
+                                        abort(line,"Expected Linear-Nonlinear multimeter parameter list: 'x','y','segment','interval','start','stop','Show'");
                                         break;
                                     }
                                 }
                                 else{
-                                    abort(line);
+                                    abort(line,"Expected any of the multimeter types ('spatial', 'temporal', 'Linear-Nonlinear') and corresponding parameters");
                                     break;
                                 }
                             }
                             else{
-                                abort(line);
+                                abort(line,"Parameter syntax error or specified module ID not found");
                                 break;
                             }
 
 
 
                         }else{
-                            abort(line);
+                            abort(line,"Expected parameter list start token ('{')");
                             break;
                         }
                     }else{
-                        abort(line);
+                        abort(line,"Expected parameter token");
                         break;
                     }
 
+                }else{
+                    // Shouldn't we abort here?
                 }
 
                 action = 0;
@@ -688,11 +693,11 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                     if (atof(token[2])>0)
                         retina.setSimTime(atof(token[2]));
                     else{
-                        abort(line);
+                        abort(line,"Expected a positive time value (>0)");
                         break;
                     }
                 }else{
-                    abort(line);
+                    abort(line,"Expected simulation time value");
                     break;
                 }
 
@@ -708,11 +713,11 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
                     if (atof(token[2])>0)
                         retina.setSimTotalRep(atof(token[2]));
                     else{
-                        abort(line);
+                        abort(line,"Expected a positive value (>0)");
                         break;
                     }
                 }else{
-                    abort(line);
+                    abort(line,"Expected number of trials value");
                     break;
                 }
 
@@ -736,8 +741,8 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
 
 //-------------------------------------------------//
 
-void FileReader::abort(int line){
-    cout << "Incorrect syntax in line " << line << endl;
+void FileReader::abort(int line, char *error_msg){
+    cout << "Incorrect syntax in line " << line << ": " << error_msg << endl;
     cout << "Aborting parsing of retina file." << endl;
     continueReading = false;
 

--- a/COREM/src/FileReader.h
+++ b/COREM/src/FileReader.h
@@ -53,7 +53,7 @@ public:
     // parsing of retina script and initialization of retina modules
     void parseFile(Retina &retina,DisplayManager &displayMg);
     bool getContReading(){return continueReading;}
-    void abort(int line);
+    void abort(int line, char *error_msg);
 };
 
 #endif // FILEREADER_H

--- a/COREM/src/InterfaceNEST.cpp
+++ b/COREM/src/InterfaceNEST.cpp
@@ -132,8 +132,8 @@ double InterfaceNEST::getValue(double cell){
 
     for(int k=1;k<retina.getNumberModules();k++){
         neuron = retina.getModule(k);
-        const char * charID = (neuron->getModuleID()).c_str();
-        if (strcmp(charID,charIDO)==0){
+        string charID = neuron->getModuleID();
+        if (charID.compare(charIDO)==0){
             neuron_to_display = k;
             break;
         }

--- a/COREM/src/Retina.cpp
+++ b/COREM/src/Retina.cpp
@@ -269,9 +269,9 @@ for (int i=1;i<modules.size();i++){
             //search for the first image
             for (int m=1;m<modules.size();m++){
                 module* n = modules[m];
-                const char * cellName1 = l[0].c_str();
-                const char * cellName2 = (n->getModuleID()).c_str();
-                if (strcmp(cellName1,cellName2)==0){
+                string cellName1 = l[0];
+                string cellName2 = n->getModuleID();
+                if (cellName1.compare(cellName2)==0){
                     accumulator = *(n->getOutput());
                     break;
                 }
@@ -283,9 +283,9 @@ for (int i=1;i<modules.size();i++){
 
                 for (int m=1;m<modules.size();m++){
                     module* n = modules[m];
-                    const char * cellName1 = l[k].c_str();
-                    const char * cellName2 = (n->getModuleID()).c_str();
-                    if (strcmp(cellName1,cellName2)==0){
+                    string cellName1 = l[k];
+                    string cellName2 = n->getModuleID();
+                    if (cellName1.compare(cellName2)==0){
 
                        if (p[k-1]==0){
                             accumulator += *(n->getOutput());

--- a/COREM/src/main.cpp
+++ b/COREM/src/main.cpp
@@ -46,8 +46,8 @@ int main(int argc, char *argv[])
         }
         closedir (dir);
     }else{
-        const char * tocreate = ("mkdir "+currentDirRoot+"results/").c_str();
-        system(tocreate);
+        string tocreate = "mkdir "+currentDirRoot+"results/";
+        system(tocreate.c_str());
     }
 
     // Create retina interface
@@ -68,9 +68,9 @@ int main(int argc, char *argv[])
         int simTime = interface.getSimTime();
         double simStep = interface.getSimStep();
 
-    //    cout << "Simulation time: "<< simTime << endl;
-    //    cout << "Trials: "<< trials << endl;
-    //    cout << "Simulation step: "<< simStep << endl;
+        //cout << "Simulation time: "<< simTime << endl;
+        //cout << "Trials: "<< trials << endl;
+        //cout << "Simulation step: "<< simStep << endl;
 
         // Simulation
         for(int i=0;i<trials;i++){
@@ -79,7 +79,8 @@ int main(int argc, char *argv[])
             InterfaceNEST interface;
             interface.allocateValues(retinaSim,"output",constants::outputfactor,i);
 
-    //        cout << "-- Trial "<< i << " --" << endl;
+            //cout << "-- Trial "<< i << " --" << endl;
+            //cout << "   AbortExecution " << interface.getAbortExecution() << endl;
 
             if(interface.getAbortExecution()==false){
                 for(int k=0;k<simTime;k+=simStep){

--- a/COREM/src/multimeter.cpp
+++ b/COREM/src/multimeter.cpp
@@ -183,24 +183,26 @@ void multimeter::showLNAnalysisAvg(int col, int row, double waitTime,double segm
 
     // read values from file
     const char* to_file = readFile(LNFile);
-
-    std::ifstream fin;
-    fin.open(to_file);
     vector<double> F;
 
-    while (!fin.eof())
+    std::ifstream fin;
+    fin.open(to_file, std::ifstream::in);
+    if(fin.is_open())
     {
-      char buf[1000];
-      fin.getline(buf,1000);
-      const char* token[1] = {};
-      token[0] = strtok(buf, "\n");
 
-      F.push_back(atof(token[0]));
+        while (!fin.eof())
+        {
+          char buf[1000];
+          fin.getline(buf,1000);
+          const char* token[1] = {};
+          token[0] = strtok(buf, "\n");
+          if(token[0] != NULL)
+             F.push_back(atof(token[0]));
 
+        }
+
+        fin.close(); 
     }
-
-    fin.close(); 
-
     // Non-linearity: The stimulus is convolved with the filter.
     // g = S*F
 
@@ -819,7 +821,7 @@ const char* multimeter::readFile(const char * File){
 
     string stringResult = getDir()+ "results/";
     const char * root = (stringResult).c_str();
-    char result[1000];
+    static char result[1000];
 
     strcpy(result,root);
     strcat(result,File);


### PR DESCRIPTION
Changes from upstream:
- multimeter::readFile method now returns a pointer to a static local variable (see repository fork commit description)
- string::c_str() method is now only called for declared string objects
- Minor Makefile flag change to prevent warnings from unused function arguments and to avoid a linking error.
- Added .gitignore file to prevent that compiled object files are added to the repository
- FileReader:abort() method now receives an string argument to print further information when a parsing error occurs.
