### PR TITLE
Added command-line arguments -h and -v, and support for 3D .inr files

### DIFF
--- a/COREM/Makefile
+++ b/COREM/Makefile
@@ -4,10 +4,10 @@ MAKEFILE      = Makefile
 
 CC            = gcc
 CXX           = g++
-CFLAGS        = -m64 -pipe -O2 -Wall -W -D_REENTRANT -fPIE $(DEFINES)
-CXXFLAGS      = -m64 -pipe -fopenmp -std=c++0x -O2 -Wall -Wno-unused-parameter -W -D_REENTRANT -fPIE $(DEFINES)
+CFLAGS        = -m64 -pipe -Wall -W -D_REENTRANT -fPIE $(DEFINES)
+CXXFLAGS      = -m64 -pipe -fopenmp -std=c++0x -Wall -Wno-unused-parameter -W -D_REENTRANT -fPIE $(DEFINES)
 LINK          = g++
-LFLAGS        = -m64 -fopenmp -Wl,-O1
+LFLAGS        = -m64 -fopenmp
 LIBS          = $(SUBLIBS) -lX11 -lpthread 
 AR            = ar cqs
 TAR           = tar -cf
@@ -69,6 +69,16 @@ TARGET        = corem
 
 
 first: all
+
+debug: CXXFLAGS += -DDEBUG -g
+debug: CFLAGS += -DDEBUG -g
+debug: first
+
+release: CXXFLAGS += -O2
+release: CFLAGS += -O2
+release: LFLAGS += -Wl,-O1
+release: first
+
 ####### Implicit rules
 
 .SUFFIXES: .o .c .cpp .cc .cxx .C
@@ -106,6 +116,7 @@ uninstall:
 files := $(shell mkdir build/)
 
 all: Makefile $(TARGET)
+
 
 $(TARGET):  $(OBJECTS)  
 	$(LINK) $(LFLAGS) -o $(TARGET) $(OBJECTS) $(OBJCOMP) $(LIBS)

--- a/COREM/corem.project
+++ b/COREM/corem.project
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CodeLite_Project Name="corem" InternalType="">
+  <Description/>
+  <Dependencies/>
+  <VirtualDirectory Name="src">
+    <File Name="src/fixationalMovGrating.cpp"/>
+    <File Name="src/StaticNonLinearity.h"/>
+    <File Name="src/DisplayManager.h"/>
+    <File Name="src/main.cpp"/>
+    <File Name="src/LinearFilter.h"/>
+    <File Name="src/ShortTermPlasticity.h"/>
+    <File Name="src/module.h"/>
+    <File Name="src/DisplayManager.cpp"/>
+    <File Name="src/impulse.h"/>
+    <File Name="src/ShortTermPlasticity.cpp"/>
+    <File Name="src/constants.h"/>
+    <File Name="src/GaussFilter.h"/>
+    <File Name="src/impulse.cpp"/>
+    <File Name="src/LinearFilter.cpp"/>
+    <File Name="src/Retina.h"/>
+    <File Name="src/InterfaceNEST.h"/>
+    <File Name="src/SingleCompartment.h"/>
+    <File Name="src/multimeter.h"/>
+    <File Name="src/fixationalMovGrating.h"/>
+    <File Name="src/module.cpp"/>
+    <File Name="src/whiteNoise.cpp"/>
+    <File Name="src/constants.cpp"/>
+    <File Name="src/FileReader.cpp"/>
+    <File Name="src/StaticNonLinearity.cpp"/>
+    <File Name="src/FileReader.h"/>
+    <File Name="src/whiteNoise.h"/>
+    <File Name="src/InterfaceNEST.cpp"/>
+    <File Name="src/GratingGenerator.h"/>
+    <File Name="src/Retina.cpp"/>
+    <File Name="src/multimeter.cpp"/>
+    <File Name="src/SingleCompartment.cpp"/>
+    <File Name="src/GaussFilter.cpp"/>
+    <File Name="src/GratingGenerator.cpp"/>
+  </VirtualDirectory>
+  <Settings Type="Dynamic Library">
+    <GlobalSettings>
+      <Compiler Options="" C_Options="" Assembler="">
+        <IncludePath Value="."/>
+      </Compiler>
+      <Linker Options="">
+        <LibraryPath Value="."/>
+      </Linker>
+      <ResourceCompiler Options=""/>
+    </GlobalSettings>
+    <Configuration Name="Debug" CompilerType="GCC" DebuggerType="GNU gdb debugger" Type="Dynamic Library" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
+      <Compiler Options="-g" C_Options="-g" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="0">
+        <IncludePath Value="."/>
+      </Compiler>
+      <Linker Options="" Required="yes"/>
+      <ResourceCompiler Options="" Required="no"/>
+      <General OutputFile="corem" IntermediateDirectory="./build" Command="./corem" CommandArguments="Retina_scripts/contrast.py" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="." PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
+      <Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">
+        <![CDATA[]]>
+      </Environment>
+      <Debugger IsRemote="no" RemoteHostName="" RemoteHostPort="" DebuggerPath="" IsExtended="no">
+        <DebuggerSearchPaths/>
+        <PostConnectCommands/>
+        <StartupCommands/>
+      </Debugger>
+      <PreBuild/>
+      <PostBuild/>
+      <CustomBuild Enabled="yes">
+        <RebuildCommand/>
+        <CleanCommand>make clean</CleanCommand>
+        <BuildCommand>make debug</BuildCommand>
+        <PreprocessFileCommand/>
+        <SingleFileCommand/>
+        <MakefileGenerationCommand/>
+        <ThirdPartyToolName>None</ThirdPartyToolName>
+        <WorkingDirectory>$(WorkspacePath)</WorkingDirectory>
+      </CustomBuild>
+      <AdditionalRules>
+        <CustomPostBuild/>
+        <CustomPreBuild/>
+      </AdditionalRules>
+      <Completion EnableCpp11="no" EnableCpp14="no">
+        <ClangCmpFlagsC/>
+        <ClangCmpFlags/>
+        <ClangPP/>
+        <SearchPaths/>
+      </Completion>
+    </Configuration>
+    <Configuration Name="Release" CompilerType="GCC" DebuggerType="GNU gdb debugger" Type="Dynamic Library" BuildCmpWithGlobalSettings="append" BuildLnkWithGlobalSettings="append" BuildResWithGlobalSettings="append">
+      <Compiler Options="" C_Options="" Assembler="" Required="yes" PreCompiledHeader="" PCHInCommandLine="no" PCHFlags="" PCHFlagsPolicy="0">
+        <IncludePath Value="."/>
+      </Compiler>
+      <Linker Options="-O2" Required="yes"/>
+      <ResourceCompiler Options="" Required="no"/>
+      <General OutputFile="corem" IntermediateDirectory="./build" Command="./corem" CommandArguments="Retina_scripts/contrast.py" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="." PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
+      <Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">
+        <![CDATA[]]>
+      </Environment>
+      <Debugger IsRemote="no" RemoteHostName="" RemoteHostPort="" DebuggerPath="" IsExtended="no">
+        <DebuggerSearchPaths/>
+        <PostConnectCommands/>
+        <StartupCommands/>
+      </Debugger>
+      <PreBuild/>
+      <PostBuild/>
+      <CustomBuild Enabled="yes">
+        <RebuildCommand/>
+        <CleanCommand>make clean</CleanCommand>
+        <BuildCommand>make release</BuildCommand>
+        <PreprocessFileCommand/>
+        <SingleFileCommand/>
+        <MakefileGenerationCommand/>
+        <ThirdPartyToolName>None</ThirdPartyToolName>
+        <WorkingDirectory>$(WorkspacePath)</WorkingDirectory>
+      </CustomBuild>
+      <AdditionalRules>
+        <CustomPostBuild/>
+        <CustomPreBuild/>
+      </AdditionalRules>
+      <Completion EnableCpp11="no" EnableCpp14="no">
+        <ClangCmpFlagsC/>
+        <ClangCmpFlags/>
+        <ClangPP/>
+        <SearchPaths/>
+      </Completion>
+    </Configuration>
+  </Settings>
+</CodeLite_Project>

--- a/COREM/corem.project
+++ b/COREM/corem.project
@@ -53,7 +53,7 @@
       </Compiler>
       <Linker Options="" Required="yes"/>
       <ResourceCompiler Options="" Required="no"/>
-      <General OutputFile="corem" IntermediateDirectory="./build" Command="./corem" CommandArguments="Retina_scripts/contrast.py" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="." PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
+      <General OutputFile="corem" IntermediateDirectory="./build" Command="./corem" CommandArguments="Retina_scripts/test.py" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="." PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
       <Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">
         <![CDATA[]]>
       </Environment>
@@ -91,7 +91,7 @@
       </Compiler>
       <Linker Options="-O2" Required="yes"/>
       <ResourceCompiler Options="" Required="no"/>
-      <General OutputFile="corem" IntermediateDirectory="./build" Command="./corem" CommandArguments="Retina_scripts/contrast.py" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="." PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
+      <General OutputFile="corem" IntermediateDirectory="./build" Command="./corem" CommandArguments="Retina_scripts/test.py" UseSeparateDebugArgs="no" DebugArguments="" WorkingDirectory="." PauseExecWhenProcTerminates="yes" IsGUIProgram="no" IsEnabled="yes"/>
       <Environment EnvVarSetName="&lt;Use Defaults&gt;" DbgSetName="&lt;Use Defaults&gt;">
         <![CDATA[]]>
       </Environment>

--- a/COREM/corem.workspace
+++ b/COREM/corem.workspace
@@ -2,11 +2,11 @@
 <CodeLite_Workspace Name="corem" Database="">
   <Project Name="corem" Path="corem.project" Active="Yes"/>
   <BuildMatrix>
-    <WorkspaceConfiguration Name="Debug" Selected="no">
+    <WorkspaceConfiguration Name="Debug" Selected="yes">
       <Environment/>
       <Project Name="corem" ConfigName="Debug"/>
     </WorkspaceConfiguration>
-    <WorkspaceConfiguration Name="Release" Selected="yes">
+    <WorkspaceConfiguration Name="Release" Selected="no">
       <Environment/>
       <Project Name="corem" ConfigName="Release"/>
     </WorkspaceConfiguration>

--- a/COREM/corem.workspace
+++ b/COREM/corem.workspace
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CodeLite_Workspace Name="corem" Database="">
+  <Project Name="corem" Path="corem.project" Active="Yes"/>
+  <BuildMatrix>
+    <WorkspaceConfiguration Name="Debug" Selected="no">
+      <Environment/>
+      <Project Name="corem" ConfigName="Debug"/>
+    </WorkspaceConfiguration>
+    <WorkspaceConfiguration Name="Release" Selected="yes">
+      <Environment/>
+      <Project Name="corem" ConfigName="Release"/>
+    </WorkspaceConfiguration>
+  </BuildMatrix>
+</CodeLite_Workspace>

--- a/COREM/src/FileReader.cpp
+++ b/COREM/src/FileReader.cpp
@@ -741,7 +741,7 @@ void FileReader::parseFile(Retina& retina, DisplayManager &displayMg){
 
 //-------------------------------------------------//
 
-void FileReader::abort(int line, char *error_msg){
+void FileReader::abort(int line, const char *error_msg){
     cout << "Incorrect syntax in line " << line << ": " << error_msg << endl;
     cout << "Aborting parsing of retina file." << endl;
     continueReading = false;

--- a/COREM/src/FileReader.h
+++ b/COREM/src/FileReader.h
@@ -53,7 +53,7 @@ public:
     // parsing of retina script and initialization of retina modules
     void parseFile(Retina &retina,DisplayManager &displayMg);
     bool getContReading(){return continueReading;}
-    void abort(int line, char *error_msg);
+    void abort(int line, const char *error_msg);
 };
 
 #endif // FILEREADER_H

--- a/COREM/src/InterfaceNEST.cpp
+++ b/COREM/src/InterfaceNEST.cpp
@@ -48,6 +48,10 @@ double InterfaceNEST::getSimStep(){
 
 //------------------------------------------------------------------------------//
 
+void  InterfaceNEST::setVerbosity(bool verbose_flag){
+    retina.setVerbosity(verbose_flag);
+}
+
 void InterfaceNEST::allocateValues(const char *retinaPath, const char * outputFile,double outputfactor,double currentRep){
 
 

--- a/COREM/src/InterfaceNEST.h
+++ b/COREM/src/InterfaceNEST.h
@@ -64,6 +64,7 @@ public:
     bool getAbortExecution(){return abortExecution;}
     Retina& getRetina(){return retina;}
     double getSimStep();
+    void setVerbosity(bool verbose_flag);
 
     // modification of generators (for optimization)
     void setWhiteNoise(double mean, double contrast1,double contrast2, double period, double switchT,string id,double start, double stop);

--- a/COREM/src/Retina.h
+++ b/COREM/src/Retina.h
@@ -14,7 +14,7 @@
  */
 
 
-#include "dirent.h"
+#include <dirent.h>
 #include <algorithm>
 
 
@@ -85,6 +85,7 @@ public:
     int getSizeX();
     int getSizeY();
     double getStep();
+    void setVerbosity(bool verbose_flag);
     void setSimCurrentRep(double r);
     void setSimTotalRep(double r);
     void setSimTime(int t);

--- a/tools/avi2inr.m
+++ b/tools/avi2inr.m
@@ -1,13 +1,18 @@
 % AVI2INR convert a AVI file movie to INRimage format
-% avi2inr(filename) opens filename.avi and creates a filename.inr file
+% avi2inr(filename, fps_mult, last_input_frame) opens filename.avi and
+% creates a filename.inr file. fps_mult indicates how many (linearly
+% interpolated) output frames will be created from each input frame.
+% last_input_frame indicates now many input frames will be read (and
+% saved). The outut video will contain aproximately
+% fps_mult * last_input_frame frames.
 % In Linux Matlab may requiere the installation of packages:
 %  - gstreamer0.10-plugins-good and gstreamer0.10-tools
 % to open .avi files.
-$ Some old versions of Matlab may also require that
+% Some old versions of Matlab may also require that
 % /usr/local/MATLAB/MATLAB_Production_Server/R2013a/sys/os/glnxa64/libstdc++.so.6 link
 % is changed to point to system libstdc++.so.6 as well
-% Example to create movie.inr from movie.avi:
-%  avi2inr('movie')
+% Example to create movie.inr from movie.avi with same frame rate and approx. length:
+%  avi2inr('movie',1,Inf)
 %
 %   See also INRWRITE, INRVIDEOWRITE.
 
@@ -18,22 +23,23 @@ $ Some old versions of Matlab may also require that
 %   it under the terms of the GNU General Public License as published by
 %   the Free Software Foundation; either version 3 of the License, or
 %   (at your option) any later version.
-function avi2inr(filename)
-fps_mult=4;
-vid = VideoReader([filename '.avi']);
-vid_out=inrfile([filename '.inr']);
-ant_frame=mean(read(vid,1),3);
-for ii = 2:10 % num_frames
-   cur_frame = mean(read(vid,ii),3);
-   for subii=1:fps_mult
+function avi2inr(filename, fps_mult, last_input_frame)
+vid_in = VideoReader([filename '.avi']);
+vid_out=inrvideowrite([filename '.inr']);
+ant_frame=mean(read(vid_in,1),3);
+num_frames = vid_in.NumberOfFrames;
+input_frame_index = 2;
+while input_frame_index <= num_frames && input_frame_index <= last_input_frame
+   cur_frame = mean(read(vid_in,input_frame_index),3);
+   for frame_subindex=1:fps_mult
       v(1,:,:)=ant_frame;
       v(2,:,:)=cur_frame;
-      int_frame=permute(uint8(interp1([0 fps_mult], v, subii-1)),[2 3 1]);
-      % imwrite(int_frame, [sprintf('fr_%04d',(ii-2)*fps_mult + subii) '.pgm']);
-      % inrwrite(int_frame,[sprintf('fr_%04d',(ii-2)*fps_mult + subii) '.inr'])
+      int_frame=permute(uint8(interp1([0 fps_mult], v, frame_subindex-1)),[2 3 1]);
+      % imwrite(int_frame, [filename sprintf('_%04d',(ii-2)*fps_mult + frame_subindex) '.pgm']);
       vid_out.add_frame(int_frame);
-      % figure(subii),imshow(int_frame);
+      % imshow(int_frame);
    end
- ant_frame=cur_frame;
+   ant_frame=cur_frame;
+   input_frame_index = input_frame_index + 1;
 end
 delete(vid_out);

--- a/tools/avi2inr.m
+++ b/tools/avi2inr.m
@@ -1,3 +1,23 @@
+% AVI2INR convert a AVI file movie to INRimage format
+% avi2inr(filename) opens filename.avi and creates a filename.inr file
+% In Linux Matlab may requiere the installation of packages:
+%  - gstreamer0.10-plugins-good and gstreamer0.10-tools
+% to open .avi files.
+$ Some old versions of Matlab may also require that
+% /usr/local/MATLAB/MATLAB_Production_Server/R2013a/sys/os/glnxa64/libstdc++.so.6 link
+% is changed to point to system libstdc++.so.6 as well
+% Example to create movie.inr from movie.avi:
+%  avi2inr('movie')
+%
+%   See also INRWRITE, INRVIDEOWRITE.
+
+%   Copyright (C) 2016 by Richard R. Carrillo 
+%   $Revision: 1.0 $  $Date: 26/9/2016 $
+
+%   This program is free software; you can redistribute it and/or modify
+%   it under the terms of the GNU General Public License as published by
+%   the Free Software Foundation; either version 3 of the License, or
+%   (at your option) any later version.
 function avi2inr(filename)
 fps_mult=4;
 vid = VideoReader([filename '.avi']);
@@ -9,12 +29,11 @@ for ii = 2:10 % num_frames
       v(1,:,:)=ant_frame;
       v(2,:,:)=cur_frame;
       int_frame=permute(uint8(interp1([0 fps_mult], v, subii-1)),[2 3 1]);
-      %imwrite(int_frame, [sprintf('fr_%04d',(ii-2)*fps_mult + subii) '.pgm']);
-      %inrwrite(int_frame,[sprintf('fr_%04d',(ii-2)*fps_mult + subii) '.inr'])
+      % imwrite(int_frame, [sprintf('fr_%04d',(ii-2)*fps_mult + subii) '.pgm']);
+      % inrwrite(int_frame,[sprintf('fr_%04d',(ii-2)*fps_mult + subii) '.inr'])
       vid_out.add_frame(int_frame);
       % figure(subii),imshow(int_frame);
    end
  ant_frame=cur_frame;
 end
 delete(vid_out);
-

--- a/tools/avi2inr.m
+++ b/tools/avi2inr.m
@@ -1,0 +1,20 @@
+function avi2inr(filename)
+fps_mult=4;
+vid = VideoReader([filename '.avi']);
+vid_out=inrfile([filename '.inr']);
+ant_frame=mean(read(vid,1),3);
+for ii = 2:10 % num_frames
+   cur_frame = mean(read(vid,ii),3);
+   for subii=1:fps_mult
+      v(1,:,:)=ant_frame;
+      v(2,:,:)=cur_frame;
+      int_frame=permute(uint8(interp1([0 fps_mult], v, subii-1)),[2 3 1]);
+      %imwrite(int_frame, [sprintf('fr_%04d',(ii-2)*fps_mult + subii) '.pgm']);
+      %inrwrite(int_frame,[sprintf('fr_%04d',(ii-2)*fps_mult + subii) '.inr'])
+      vid_out.add_frame(int_frame);
+      % figure(subii),imshow(int_frame);
+   end
+ ant_frame=cur_frame;
+end
+delete(vid_out);
+

--- a/tools/inrfile.m
+++ b/tools/inrfile.m
@@ -1,0 +1,78 @@
+classdef inrfile<handle
+   properties
+      ydim,xdim,zdim
+      inr_type
+      inr_type_len
+      fh
+      inr_header_len=256;
+      inr_header_start_temp=[...
+         '#INRIMAGE-4#{\n' ...
+         'XDIM=%d\n' ...
+         'YDIM=%d\n' ...
+         'ZDIM=%d\n' ...
+         'VDIM=1\n' ...
+         'VX=1\n' ...
+         'VY=1\n' ...
+         'VZ=1\n' ...
+         'TYPE=%s\n' ...
+         'PIXSIZE=%d bits\n' ...
+         'SCALE=2**0\n' ...
+         'CPU=pc\n'];
+      inr_header_end=sprintf('\n##}\n');
+      inr_type_list={'float', 'signed fixed', 'unsigned fixed'};
+      data_class
+      data_size
+   end
+   methods
+      function obj = inrfile(filename)
+         obj.inr_type_len = 0; % When this proprty is set to 0, it indicates that the other properties are not set yet.
+         obj.fh=fopen(filename,'w');
+         if nargin ~= -1
+             fprintf(obj.fh,repmat(' ',1,obj.inr_header_len));
+         else
+            error(['Creating file ' filename])
+         end
+      end
+      function add_frame(obj, frame)
+         if obj.inr_type_len == 0 % Image porperties are not stablished yet: Set image object properties
+            obj.data_class=class(frame);
+            obj.data_size=size(frame);
+            switch(obj.data_class)
+               case {'single', 'double'}
+                  obj.inr_type=obj.inr_type_list{1};
+               case {'int8', 'int16', 'int32', 'int64'}
+                  obj.inr_type=obj.inr_type_list{2};
+               case {'uint8', 'uint16', 'uint32', 'uint64'}
+                  obj.inr_type=obj.inr_type_list{3};
+            end
+
+            switch(obj.data_class)
+               case {'int8', 'uint8'}
+                  obj.inr_type_len=8;
+               case {'int16', 'uint16'}
+                  obj.inr_type_len=16;
+               case {'int32', 'uint32', 'single'}
+                  obj.inr_type_len=32;
+               case {'int64', 'uint64', 'double'}
+                  obj.inr_type_len=64;
+            end
+            [obj.ydim,obj.xdim]=size(frame);
+            obj.zdim=0; % No frames in the video so far
+         end
+            if isequal(obj.data_class,class(frame)) && isequal(obj.data_size,size(frame)) %check if the specied frame properties match
+               fwrite(obj.fh,permute(frame,[2 1 3]),obj.data_class);
+               obj.zdim=obj.zdim+1;
+            else
+               error('properties of specified frame does not match those of previous ones');
+            end
+      end
+      function delete(obj)
+         fseek(obj.fh,0,'bof');
+         inr_header_start=sprintf(obj.inr_header_start_temp, obj.xdim, obj.ydim, obj.zdim, obj.inr_type, obj.inr_type_len);
+         fprintf(obj.fh,inr_header_start);
+         fprintf(obj.fh,repmat('\n',1,obj.inr_header_len-length(inr_header_start)-length(obj.inr_header_end)));
+         fprintf(obj.fh,obj.inr_header_end);
+         fclose(obj.fh);
+      end
+   end
+end

--- a/tools/inrvideowrite.m
+++ b/tools/inrvideowrite.m
@@ -1,4 +1,27 @@
-classdef inrfile<handle
+% inrvideowrite class creatres a movie file with INRimage format
+% 
+% To create the movie firstly the class constructor must be called.
+% Then we call the add_frame method one time per each frame we want to
+% insert in the movie
+% Finally we call the destructor of the class to update and close the file
+% Example to create a 3-frame 320x240 movie:
+%  vid = inrvideowrite('movie.inr')
+%  vid.add_frame(uint8(255*ones(240,320)))
+%  vid.add_frame(uint8(zeros(240,320)))
+%  vid.add_frame(uint8(255*ones(240,320)))
+%  vid.delete()
+% The input matrix of add_frame must have the same size and data type for all the calls.
+%
+%   See also INRWRITE.
+
+%   Copyright (C) 2016 by Richard R. Carrillo 
+%   $Revision: 1.0 $  $Date: 26/9/2016 $
+
+%   This program is free software; you can redistribute it and/or modify
+%   it under the terms of the GNU General Public License as published by
+%   the Free Software Foundation; either version 3 of the License, or
+%   (at your option) any later version.
+classdef inrvideowrite<handle
    properties
       ydim,xdim,zdim
       inr_type
@@ -24,7 +47,7 @@ classdef inrfile<handle
       data_size
    end
    methods
-      function obj = inrfile(filename)
+      function obj = inrvideowrite(filename)
          obj.inr_type_len = 0; % When this proprty is set to 0, it indicates that the other properties are not set yet.
          obj.fh=fopen(filename,'w');
          if nargin ~= -1

--- a/tools/inrwrite.m
+++ b/tools/inrwrite.m
@@ -1,0 +1,46 @@
+function inrwrite(im_mat,filename)
+
+inr_header_len=256;
+inr_header_start_temp=[...
+   '#INRIMAGE-4#{\n' ...
+   'XDIM=%d\n' ...
+   'YDIM=%d\n' ...
+   'ZDIM=%d\n' ...
+   'VDIM=1\n' ...
+   'VX=1\n' ...
+   'VY=1\n' ...
+   'VZ=1\n' ...
+   'TYPE=%s\n' ...
+   'PIXSIZE=%d bits\n' ...
+   'SCALE=2**0\n' ...
+   'CPU=pc\n'];
+inr_header_end=sprintf('\n##}\n');
+
+inr_type_list={'float', 'signed fixed', 'unsigned fixed'};
+switch(class(im_mat))
+   case {'single', 'double'}
+      inr_type=inr_type_list{1};
+   case {'int8', 'int16', 'int32', 'int64'}
+      inr_type=inr_type_list{2};
+   case {'uint8', 'uint16', 'uint32', 'uint64'}
+      inr_type=inr_type_list{3};
+end
+
+switch(class(im_mat))
+   case {'int8', 'uint8'}
+      inr_type_len=8;
+   case {'int16', 'uint16'}
+      inr_type_len=16;
+   case {'int32', 'uint32', 'single'}
+      inr_type_len=32;
+   case {'int64', 'uint64', 'double'}
+      inr_type_len=64;
+end  
+[ydim,xdim,zdim]=size(im_mat);
+inr_header_start=sprintf(inr_header_start_temp, xdim, ydim, zdim, inr_type, inr_type_len);
+fh=fopen(filename,'w');
+fprintf(fh,inr_header_start);
+fprintf(fh,repmat('\n',1,inr_header_len-length(inr_header_start)-length(inr_header_end)));
+fprintf(fh,inr_header_end);
+fwrite(fh,permute(im_mat,[2 1 3]),class(im_mat));
+fclose(fh);

--- a/tools/inrwrite.m
+++ b/tools/inrwrite.m
@@ -1,5 +1,23 @@
-function inrwrite(im_mat,filename)
+% inrwrite creatres INRimage file (image or movie)
+% 
+% inrwrite(im_mat,filename)
+% When used to create a image inrwrite has similar parameter format as
+% imwrite.
+% Example to create a 320x240 white image:
+%  inrwrite(uint8(255*ones(240,320)),'image.inr')
+% When used to create a movie in_mat has an extra dimension whose
+% coordinates indicate the frame number
+%
+%   See also RETSPKPLOT.
 
+%   Copyright (C) 2016 by Richard R. Carrillo 
+%   $Revision: 1.0 $  $Date: 26/9/2016 $
+
+%   This program is free software; you can redistribute it and/or modify
+%   it under the terms of the GNU General Public License as published by
+%   the Free Software Foundation; either version 3 of the License, or
+%   (at your option) any later version.
+function inrwrite(im_mat,filename)
 inr_header_len=256;
 inr_header_start_temp=[...
    '#INRIMAGE-4#{\n' ...

--- a/tools/retspkplot.m
+++ b/tools/retspkplot.m
@@ -1,0 +1,46 @@
+% This Matlab script plot a raster plot of the output spike activity of file spikes.spk
+% For large activity files consider displaying only part of the file using the script:
+%  retspkplotpar.m
+%
+%   See also RETSPKPLOTPAR.
+
+%   Copyright (C) 2016 by Richard R. Carrillo 
+%   $Revision: 1.1 $  $Date: 26/9/2016 $
+%   (adapted from noout2 from EDLUT repository)
+
+%   This program is free software; you can redistribute it and/or modify
+%   it under the terms of the GNU General Public License as published by
+%   the Free Software Foundation; either version 3 of the License, or
+%   (at your option) any later version.
+output=load('spikes.spk');
+lx=max(output(:,2));
+
+spk=sort(output(:,1)');
+
+nspk=[];
+if length(spk) > 0
+    reps=1;
+    nspk(1)=spk(1);
+else
+    reps=0;
+end
+for n=2:length(spk),
+    if spk(n-1) ~= spk(n)
+        reps=reps+1;
+        nspk(reps)=spk(n);
+    end
+end
+
+tot_spks=0;
+for n=1:reps
+    tspk=output(find(output(:,1)==nspk(n)),2);
+    tot_spks=tot_spks+length(tspk);
+    line((tspk*ones(1,2))',(ones(length(tspk),1)*[n-0.25,n+0.25])','Color','b');
+end
+axis tight
+xlabel('time');
+ylabel('neuron number');
+display(['Total number of spikes: ' num2str(tot_spks)]);
+display(['Number of spiking neurons: ' num2str(reps)]);
+set(gca,'YTick',1:reps);
+set(gca,'YTickLabel',nspk);

--- a/tools/retspkplotpar.m
+++ b/tools/retspkplotpar.m
@@ -1,0 +1,216 @@
+%RETSPKPLOTPAR plots a raster plot of the neural spike activity
+%   This script reads the simulation spikes generated during the retina 
+%   simulation from the activity output file and plot them.
+%   RETSPKPLOTPAR var_type t_ini t_end only reads the spikes from
+%   time t_ini to t_end (in seconds)
+%   RETSPKPLOTPAR var_type t_ini t_end neu_ini neu_end only reads the spikes
+%   of neurons from neu_ini to neu_end and in time from t_ini to t_end
+%   var_type specifies how the activity will be plotted.
+%   var_type must be: ra
+%    ra: Displais a normal raster plot of the activity
+%        (the whole specified period of the simulation is plotted)
+%   example to generate a raster plot of simulation activity in the time interval 0 1:
+%      retspkplotpar ra 0 1
+%
+%   See also RETSPKPLOT.
+
+%   Copyright (C) 2016 by Richard R. Carrillo 
+%   $Revision: 1.3 $  $Date: 26/9/2016 $
+%   (adapted from noout2par from EDLUT repository)
+
+%   This program is free software; you can redistribute it and/or modify
+%   it under the terms of the GNU General Public License as published by
+%   the Free Software Foundation; either version 3 of the License, or
+%   (at your option) any later version.
+function retspkplotpar(varargin)
+
+LOG_FILE='spikes.spk'; % log file name
+sim_slot_time=0.1e-3; % approx. simulation step length in seconds
+
+nargs=nargin;
+if nargin > 0
+   v=varargin{1};
+   if ~isequal(v,'ra') && ~isequal(v,'ra')
+      display('Incorrect value of the first argument');
+      nargs=0;
+   end
+end
+
+if nargs ~= 1 && nargs ~= 3 && nargs ~= 5
+      disp('You must specify 1, 3 or 5 arguments');
+      disp('retspkplotpar plot_type [start_time end_time [first_neuron last_neuron]]');
+      disp('type: help retspkplotpar for more help');
+end
+
+if nargs == 1 % the whole file must be loaded
+    disp(['loading log file: ' LOG_FILE ' completely']);
+    disp(' 100%');
+    activity_list=load(LOG_FILE);
+    tot_num_cols=size(activity_list,2);
+else % only a part of the file must be loaded
+    start_time=str2num(varargin{2});
+    end_time=str2num(varargin{3});
+    disp(['Partially loading activity file ' LOG_FILE ' from time ' num2str(start_time) ' to ' num2str(end_time)]);
+    fid = fopen(LOG_FILE,'rt');
+    if fid ~= -1
+        fseek(fid,-1,'eof');
+        filelength=ftell(fid); % get log file size
+        findline_backwards(fid); % set file reading pointer to the line start
+        last_line_txt=fgetl(fid); % load last register
+        last_line=str2num(last_line_txt);
+        last_file_time=last_line(2); % last register time
+        tot_num_cols=length(last_line); % total number of columns in the file
+        fseek(fid,fix(filelength*(start_time/last_file_time)),'bof');
+        findline_backwards(fid);
+        activity_list=read_file_part(fid,start_time,end_time);
+        fclose(fid);
+        if last_file_time < start_time
+            disp('Error: The specified start_time is no included in the file')
+            return
+        end
+    else
+        disp(['Cannot output spike file: ' LOG_FILE]);
+        return
+    end
+end
+if nargs == 5 % only some neurons must be plotted
+    first_neu=str2num(varargin{4});
+    last_neu=str2num(varargin{5});
+    activity_list=activity_list(activity_list(:,1) >= first_neu & activity_list(:,1) <= last_neu,:); % remove unwanted neurons from the list
+end
+
+neu_list_rep=sort(activity_list(:,1)');
+
+neu_list=[];
+if ~isempty(neu_list_rep)
+    num_spk_neus=1;
+    neu_list(1)=neu_list_rep(1);
+else
+    num_spk_neus=0;
+end
+for nneu=2:length(neu_list_rep),
+    if neu_list_rep(nneu-1) ~= neu_list_rep(nneu)
+        num_spk_neus=num_spk_neus+1;
+        neu_list(num_spk_neus)=neu_list_rep(nneu);
+    end
+end
+
+disp('Creating figure...');
+
+switch(v)
+case 'ra'
+    tot_spks=0;
+    for nneu=1:num_spk_neus
+        cur_neu_spk_times=activity_list(find(activity_list(:,1)==neu_list(nneu)),2);
+        tot_spks=tot_spks+length(cur_neu_spk_times);
+        line((cur_neu_spk_times*ones(1,2))',(ones(length(cur_neu_spk_times),1)*[nneu-0.25,nneu+0.25])','Color','b');
+    end
+    axis tight
+    xlabel('time');
+    ylabel('neuron number');
+    set(gca,'YTick',1:num_spk_neus);
+    
+    % find out what ticksthin out y-axis tick labels
+    neu_tick_list={neu_list(1)};
+    last_included_neu=1;
+    max_number_of_yticks=30; % in order not to overlap them
+    max_intertick_interval=num_spk_neus/max_number_of_yticks;
+    for nneu=2:num_spk_neus,
+        if neu_list(nneu-1) ~= neu_list(nneu)-1 || (nneu-last_included_neu) > max_intertick_interval || nneu==num_spk_neus
+            neu_tick_list{nneu}=neu_list(nneu); % include nonconsecutive neuron ticks or spaced-enough ones
+            last_included_neu=nneu;
+        else
+            neu_tick_list{nneu}=[]; % do not show this tick
+        end
+    end
+    set(gca,'YTickLabel',neu_tick_list);
+    display(['Total number of spikes: ' num2str(tot_spks)]);
+    display(['Number of spiking neurons: ' num2str(num_spk_neus)]);
+end
+
+% READ_LINE_TIME gets the time of the next register from the simulation-log file.
+%    REGTIME = READ_FILE_PART(FID) advances the file position indicator in the
+%    file associated with the given FID to the beginning of the next text
+%    line, then read and returns that register's time.
+   function reg_time=read_line_time(fid)
+      time_is_read=0;
+      reg_time=-1;
+      while time_is_read==0
+         [reg_time,time_is_read]=fscanf(fid,'%*d %g',1);
+         if time_is_read==0
+            fgetl(fid);
+            if feof(fid)
+               time_is_read=1;
+               reg_time=Inf;
+            end
+         end
+      end
+   end
+
+% FINDLINE_BACKWARDS move the a file pointer back to the beginning of the
+% previous text line.
+%    FINDLINE_BACKWARDS(FID) repositions the file position indicator in the
+%    file associated with the given FID. FINDLINE_BACKWARDS sets the
+%    position indicator to the byte at beginning of the line before the 
+%    current one.
+   function findline_backwards(fid)
+      newline=sprintf('\n');
+      tchar=' '; % look for the current-file-line start position
+      while ~isempty(tchar) && isempty(strfind(tchar,newline))
+         if fseek(fid,-2,'cof')==-1
+             fseek(fid,0,'bof');
+             break
+         end
+         tchar = fscanf(fid,'%1c',1);
+      end
+   end
+
+% READ_FILE_PART loads registers from the simulation-log file.
+%    REGS = READ_FILE_PART(FID,STARTTIME,ENDTIME) returns the registers of
+%    a file associated with file identifier FID as a MATLAB matrix. Only
+%    the registers from STARTTIME to ENDTIME are loaded.
+   function regs=read_file_part(fid,starttime,endtime)
+      disp(' Searching for specified registers in the file...')
+      while ftell(fid) > 0 && read_line_time(fid) > starttime
+         findline_backwards(fid); % go back to the current line start
+         fseek(fid,-1,'cof'); % jump before \n
+         findline_backwards(fid); % go back to the previous line start
+      end
+      findline_backwards(fid);
+      while read_line_time(fid) < starttime
+         fgetl(fid); % jump after \n
+      end
+      findline_backwards(fid);      
+      disp(' Loading registers from the file...')
+      disp(' 00%')
+      app_regs_size=ceil((endtime-starttime)/sim_slot_time);  % estimated size for regs
+      regs=zeros(app_regs_size,tot_num_cols); % allocate matrix memory (for execution time optmization)
+      regs_size=0;
+      cur_file_time=starttime;
+      tline=' ';
+      while cur_file_time < endtime && ischar(tline) && ~isempty(tline)
+         tline=fgetl(fid);
+         if ischar(tline) && ~isempty(tline) && isempty(~strfind(tline,'%'))
+            vline=str2num(tline);
+            regs_size=regs_size+1;
+            regs(regs_size,:)=vline;
+            cur_file_time=vline(2);
+            if mod(regs_size,fix(app_regs_size/100)) == 0 && cur_file_time > starttime
+               new_app_regs_size=ceil(regs_size*(endtime-starttime)/(cur_file_time-starttime)); % new estimation about the size of the matrix needed to store all the registers
+               if new_app_regs_size > app_regs_size
+                   regs=[regs;zeros(new_app_regs_size-app_regs_size,tot_num_cols)]; % resize (extend) the matrix size
+                   app_regs_size=new_app_regs_size;
+               end
+               progress_percentage=(cur_file_time-starttime)/(endtime-starttime)*100;
+               if progress_percentage > 99
+                   progress_percentage=99;
+               end
+               fprintf(1,'\b\b\b\b% 3.f%%',progress_percentage);
+            end
+         end
+      end
+      regs=regs(1:regs_size,:); % trim array in case of initial overdimensioning
+      fprintf(1,'\b\b\b\b100%%\n');
+   end
+
+end


### PR DESCRIPTION
Changes made:
- The user can now get command-line syntax help through the -h parameter, and they can activate the verbose mode through the -v parameter.
- The user can specify a single file in retina.Input('sequence',{'filename'}). This file can contain a sequence of images, as in the case of .inr file format.
- When the input image sequence is loaded from a directory, subdirectories are ignored to avoid loading errors.
- Some Matlab functions have been added to generate an .inr file from an .avi file or from Matlab matrices. Some other scripts have been added to show raster plots from spike activity files (tools folder).
- Project files have been added to allow the compilation and debug of COREM using CodeLite development environment.
- Makefile has been modified to accept the optional parameters release and debug.
- -O2 compilation flag has been temporally removed to ease to the project debug during development.
