### PR TITLE
Fixed crash in StreamingInput when connection is closed (end of input…

### DIFF
--- a/COREM/src/SequenceInput.cpp
+++ b/COREM/src/SequenceInput.cpp
@@ -34,6 +34,7 @@ SequenceInput::SequenceInput(const SequenceInput &copy):module(copy){
     CurrentInFrameInd = copy.CurrentInFrameInd;
     inputFileList = copy.inputFileList;
     inputMovie = copy.inputMovie;
+    endOfInput = copy.endOfInput;
 
     outputImage=new CImg<double>(*copy.outputImage);
 }

--- a/COREM/src/SingleCompartment.cpp
+++ b/COREM/src/SingleCompartment.cpp
@@ -219,7 +219,7 @@ bool SingleCompartment::setParameters(vector<double> params, vector<string> para
                 else
                     correct = false;
             }else
-                correct = false;
+                correct = false; // If number_conductance_ports <> 0, then at least two reversal potential must specified (number_conductance_ports>0), a conductance channel and the leaking reversal potential
 
             g_port+=1;
         }

--- a/COREM/src/StreamingInput.h
+++ b/COREM/src/StreamingInput.h
@@ -53,6 +53,7 @@ protected:
     pthread_t Receiver_thread_id; // ID of the thread created to receive images
     struct receiver_params receiver_vars; // Variables shared between the class object and the thread
     double NextFrameTime; // Time at which the next frame must be received
+    bool endOfInput; // Indicates that the end of input has been reached (connection closed by other end), sext module output should be NULL
     
     // StreamingInput operation parameters
     int SkipNInitFrames; // Number of of frames to skip just at the beginning of the stream


### PR DESCRIPTION
…): the module returned a pointer to the outputImage buffer which has freed after end of input. Now the buffer is not freed (same fix as in SequenceInput)